### PR TITLE
feat: add proj_normalize_for_visualization

### DIFF
--- a/pj.go
+++ b/pj.go
@@ -42,6 +42,17 @@ func (p *PJ) Destroy() {
 	}
 }
 
+// Returns a new PJ instance whose axis order is the one expected for visualization
+// purposes. If the axis order of its source or target CRS is northing,easting, then
+// an axis swap operation will be inserted.
+// The axis order of geographic CRS will be longitude, latitude [,height], and the
+// one of projected CRS will be easting, northing [, height]
+func (p *PJ) NormalizeForVisualization() (*PJ, error) {
+	p.context.Lock()
+	defer p.context.Unlock()
+	return p.context.newPJ(C.proj_normalize_for_visualization(p.context.pjContext, p.pj))
+}
+
 // Forward transforms coord in the forward direction.
 func (p *PJ) Forward(coord Coord) (Coord, error) {
 	return p.Trans(DirectionFwd, coord)


### PR DESCRIPTION
Hello!

This pull request introduces support for the `proj_normalize_for_visualization` function. 
It is beneficial in applications using different coordinate systems, especially if users can provide them in various formats.

Let's analyze EPSG:2180. Unlike most usually used CRS, it has (northing, easting) axis order by default. But only if it is provided by EPSG code (or WKT). If the PROJ4 string is passed to the PROJ library, the output order is (easting, northing).

Determining proper axis order on our own is a nightmare. The function introduced in this MR is a solution for the problem.

Best regards
Slawek