### PR TITLE
fix: use size_t in place of ulong

### DIFF
--- a/pj.go
+++ b/pj.go
@@ -171,7 +171,7 @@ func (p *PJ) TransArray(direction Direction, coords []Coord) error {
 	lastErrno := C.proj_errno_reset(p.pj)
 	defer C.proj_errno_restore(p.pj, lastErrno)
 
-	if errno := int(C.proj_trans_array(p.pj, (C.PJ_DIRECTION)(direction), (C.ulong)(len(coords)), (*C.PJ_COORD)(unsafe.Pointer(&coords[0])))); errno != 0 {
+	if errno := int(C.proj_trans_array(p.pj, (C.PJ_DIRECTION)(direction), (C.size_t)(len(coords)), (*C.PJ_COORD)(unsafe.Pointer(&coords[0])))); errno != 0 {
 		return p.context.newError(errno)
 	}
 	return nil


### PR DESCRIPTION
ulong on Windows is 4 byte long whereas size_t is 8 bytes. Since Go disallows implicit type conversions, compilation on Windows fails with the following error
`.\pj.go:174:72: cannot use (_Ctype_ulong)(len(coords)) (value of type _Ctype_ulong) as _Ctype_ulonglong value in variable declaration`
Using C.size_t instead of C.ulong makes it possible to compile go-proj on Windows. (It also make the code a bit more portable IMO)