### PR TITLE
feat: implement SetSearchPaths

### DIFF
--- a/context.go
+++ b/context.go
@@ -39,6 +39,22 @@ func (c *Context) Destroy() {
 	}
 }
 
+// SetSearchPaths sets the paths PROJ should be exploring to find the PROJ Data files.
+func (c *Context) SetSearchPaths(paths []string) {
+	c.Lock()
+	defer c.Unlock()
+	cPaths := make([]*C.char, len(paths))
+	var pathPtr unsafe.Pointer
+	for i, path := range paths {
+		cPaths[i] = C.CString(path)
+		defer C.free(unsafe.Pointer(cPaths[i]))
+	}
+	if len(paths) > 0 {
+		pathPtr = unsafe.Pointer(&cPaths[0])
+	}
+	C.proj_context_set_search_paths(c.pjContext, C.int(len(cPaths)), (**C.char)(pathPtr))
+}
+
 func (c *Context) Lock() {
 	c.mutex.Lock()
 }

--- a/context_test.go
+++ b/context_test.go
@@ -139,3 +139,18 @@ func TestContext_NewFromArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestContext_SetSearchPaths(t *testing.T) {
+	defer runtime.GC()
+
+	context := proj.NewContext()
+	assert.NotZero(t, context)
+
+	// The C function does not return any error so we only validate
+	// that executing the SetSearchPaths function call
+	// does not panic considering various boundary conditions
+	context.SetSearchPaths(nil)
+	context.SetSearchPaths([]string{})
+	context.SetSearchPaths([]string{"/tmp/data"})
+	context.SetSearchPaths([]string{"/tmp/data", "/tmp/data2"})
+}


### PR DESCRIPTION
### What change
This PR implements a `SetSearchPaths ` function on the `Context` object to allow users of the library to instruct Proj to search for data files in the provided locations.

To perform this operation, this function calls the underlying C function [proj_context_set_search_paths](https://proj.org/en/9.5/development/reference/functions.html#c.proj_context_set_search_paths) passing as input the required parameters:
- The PJ Context
- An int specifying the number of paths
- A pointer to the list of paths, or `nil` if the number of paths is zero

### Why this change
Without this change, any software depending on this library needs to make sure that the `PROJ_DATA` environment variable is set. This change enables software to programmatically set the data discovery paths per each individual context without relying on global environment variables.

### Testing
I have tested this function in a program I am developing and checked it worked. I have also written a unit test, although it is of limited usefulness since the C function does not return any error.