### PR TITLE
Fix: swap x and y in NewCoord

### DIFF
--- a/proj.go
+++ b/proj.go
@@ -57,9 +57,9 @@ func (a *Area) Destroy() {
 	}
 }
 
-// NewCoord returns a new Coord.
-func NewCoord(x, y, z, m float64) Coord {
-	return Coord{x, y, z, m}
+// NewCoord returns a new Coord where y is latitude and x longitude
+func NewCoord(y, x, z, m float64) Coord {
+	return Coord{y, x, z, m}
 }
 
 // DegToRad returns a new Coord with the first two elements transformed from


### PR DESCRIPTION
x and y are swapped to match lat/lon terminology of proj and other gis solutions on creation. Clarify in function comment.

#26 describes the problem which should be solved by applying this change